### PR TITLE
refactor(bootstrap,application): rename InfrastructureException to BootstrapException and align exception packages

### DIFF
--- a/src/main/java/io/github/blueprintplatform/codegen/application/error/exception/ApplicationException.java
+++ b/src/main/java/io/github/blueprintplatform/codegen/application/error/exception/ApplicationException.java
@@ -1,30 +1,33 @@
-package io.github.blueprintplatform.codegen.bootstrap.error.exception;
+package io.github.blueprintplatform.codegen.application.error.exception;
 
 import java.io.Serial;
 
-public abstract class InfrastructureException extends RuntimeException {
+public abstract class ApplicationException extends RuntimeException {
+
   @Serial private static final long serialVersionUID = 1L;
 
   private final String messageKey;
   private final transient Object[] args;
 
-  protected InfrastructureException(String messageKey, Object... args) {
+  protected ApplicationException(String messageKey, Object... args) {
     super(messageKey);
     this.messageKey = messageKey;
     this.args = args;
   }
 
-  protected InfrastructureException(String messageKey, Throwable cause, Object... args) {
+  protected ApplicationException(String messageKey, Throwable cause, Object... args) {
     super(messageKey, cause);
     this.messageKey = messageKey;
     this.args = args;
   }
 
   protected static Object[] prepend(Object first, Object... rest) {
-    int extra = (rest == null) ? 0 : rest.length;
+    int extra = rest == null ? 0 : rest.length;
     Object[] merged = new Object[1 + extra];
     merged[0] = first;
-    if (extra > 0) System.arraycopy(rest, 0, merged, 1, extra);
+    if (extra > 0) {
+      System.arraycopy(rest, 0, merged, 1, extra);
+    }
     return merged;
   }
 

--- a/src/main/java/io/github/blueprintplatform/codegen/application/error/exception/InvalidArtifactKeyException.java
+++ b/src/main/java/io/github/blueprintplatform/codegen/application/error/exception/InvalidArtifactKeyException.java
@@ -1,4 +1,4 @@
-package io.github.blueprintplatform.codegen.application.exception;
+package io.github.blueprintplatform.codegen.application.error.exception;
 
 public final class InvalidArtifactKeyException extends ApplicationException {
 

--- a/src/main/java/io/github/blueprintplatform/codegen/application/port/out/artifact/ArtifactKey.java
+++ b/src/main/java/io/github/blueprintplatform/codegen/application/port/out/artifact/ArtifactKey.java
@@ -1,6 +1,6 @@
 package io.github.blueprintplatform.codegen.application.port.out.artifact;
 
-import io.github.blueprintplatform.codegen.application.exception.InvalidArtifactKeyException;
+import io.github.blueprintplatform.codegen.application.error.exception.InvalidArtifactKeyException;
 import java.util.Arrays;
 
 public enum ArtifactKey {

--- a/src/main/java/io/github/blueprintplatform/codegen/bootstrap/error/exception/BootstrapException.java
+++ b/src/main/java/io/github/blueprintplatform/codegen/bootstrap/error/exception/BootstrapException.java
@@ -1,33 +1,30 @@
-package io.github.blueprintplatform.codegen.application.exception;
+package io.github.blueprintplatform.codegen.bootstrap.error.exception;
 
 import java.io.Serial;
 
-public abstract class ApplicationException extends RuntimeException {
-
+public abstract class BootstrapException extends RuntimeException {
   @Serial private static final long serialVersionUID = 1L;
 
   private final String messageKey;
   private final transient Object[] args;
 
-  protected ApplicationException(String messageKey, Object... args) {
+  protected BootstrapException(String messageKey, Object... args) {
     super(messageKey);
     this.messageKey = messageKey;
     this.args = args;
   }
 
-  protected ApplicationException(String messageKey, Throwable cause, Object... args) {
+  protected BootstrapException(String messageKey, Throwable cause, Object... args) {
     super(messageKey, cause);
     this.messageKey = messageKey;
     this.args = args;
   }
 
   protected static Object[] prepend(Object first, Object... rest) {
-    int extra = rest == null ? 0 : rest.length;
+    int extra = (rest == null) ? 0 : rest.length;
     Object[] merged = new Object[1 + extra];
     merged[0] = first;
-    if (extra > 0) {
-      System.arraycopy(rest, 0, merged, 1, extra);
-    }
+    if (extra > 0) System.arraycopy(rest, 0, merged, 1, extra);
     return merged;
   }
 

--- a/src/main/java/io/github/blueprintplatform/codegen/bootstrap/error/exception/ProfileConfigurationException.java
+++ b/src/main/java/io/github/blueprintplatform/codegen/bootstrap/error/exception/ProfileConfigurationException.java
@@ -1,6 +1,6 @@
 package io.github.blueprintplatform.codegen.bootstrap.error.exception;
 
-public final class ProfileConfigurationException extends InfrastructureException {
+public final class ProfileConfigurationException extends BootstrapException {
   public static final String KEY_PROFILE_NOT_FOUND = "bootstrap.profile.not.found";
   public static final String KEY_ARTIFACT_NOT_FOUND = "bootstrap.artifact.not.found";
   public static final String KEY_TEMPLATE_BASE_MISSING = "bootstrap.template.base.missing";

--- a/src/main/java/io/github/blueprintplatform/codegen/bootstrap/wiring/in/cli/CodegenCliExceptionHandler.java
+++ b/src/main/java/io/github/blueprintplatform/codegen/bootstrap/wiring/in/cli/CodegenCliExceptionHandler.java
@@ -1,8 +1,8 @@
 package io.github.blueprintplatform.codegen.bootstrap.wiring.in.cli;
 
 import io.github.blueprintplatform.codegen.adapter.error.exception.base.AdapterException;
-import io.github.blueprintplatform.codegen.application.exception.ApplicationException;
-import io.github.blueprintplatform.codegen.bootstrap.error.exception.InfrastructureException;
+import io.github.blueprintplatform.codegen.application.error.exception.ApplicationException;
+import io.github.blueprintplatform.codegen.bootstrap.error.exception.BootstrapException;
 import io.github.blueprintplatform.codegen.domain.error.exception.DomainException;
 import java.io.IOException;
 import java.util.Locale;
@@ -49,9 +49,8 @@ public class CodegenCliExceptionHandler implements IExecutionExceptionHandler {
         printLocalizedError(cmd, adapterException.getMessageKey(), adapterException.getArgs());
         yield 3;
       }
-      case InfrastructureException infrastructureException -> {
-        printLocalizedError(
-            cmd, infrastructureException.getMessageKey(), infrastructureException.getArgs());
+      case BootstrapException bootstrapException -> {
+        printLocalizedError(cmd, bootstrapException.getMessageKey(), bootstrapException.getArgs());
         yield 3;
       }
       case IOException ioException -> {


### PR DESCRIPTION
## 🎯 Summary

This PR clarifies exception semantics at architectural boundaries by explicitly separating **bootstrap-level failures** from generic infrastructure or adapter concerns. It renames the bootstrap base exception to reflect its true responsibility and aligns application exception packages for consistency, without changing any runtime behavior or error contracts.

The goal is **naming precision and boundary clarity**, not functional change.

---

## 📦 Changes

* Introduced `BootstrapException` as the bootstrap-specific base exception
* Updated `ProfileConfigurationException` to extend `BootstrapException`
* Aligned application exceptions under `application.error.exception`
* Preserved existing `messageKey + args` error contract across all layers

---

## 🧠 Architectural Impact

* **Domain purity:** unaffected
* **Port / adapter boundaries:** unchanged
* **Profile behavior / artifact ordering:** unchanged
* **Architecture governance / enforcement:** unchanged

This change is purely semantic and structural, improving long-term maintainability and architectural readability.

---

## 🧪 Validation

* Existing unit tests continue to pass
* No changes to generated output
* No runtime behavior changes
* Local build verified with `mvn -q -ntp clean verify`

---

## ✅ Checklist

* [x] Scope is minimal and focused
* [x] Domain layer remains framework-agnostic
* [x] Application layer contains no business logic
* [x] Ports express intent, not implementation
* [x] Adapters contain all IO / framework specifics
* [x] Build passes locally: `mvn -q -ntp clean verify`
* [x] No unintended changes to generated output

---

## 🧾 Metadata

**Type:** refactor
**Layer:** bootstrap, application
**Target Release:** v1.0.0

---

> 💡 *Notes*
>
> This PR intentionally favors **architectural clarity over convenience**.
> It establishes clearer semantic contracts for future evolution (e.g. additional bootstrap phases or startup validation rules) without i
